### PR TITLE
Add a `build_network.sh` script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN git clone --depth=1 https://github.com/anoma/namada.git /usr/local/src/namad
 WORKDIR /usr/local/src/namada
 
 # BASE_POINT should be an ancestor of REF that shares the same toolchain
-ARG BASE_POINT=v0.11.0
+ARG BASE_POINT=v0.12.1
 RUN git fetch --tags
 RUN git fetch --depth=1 origin $BASE_POINT && git checkout $BASE_POINT
 # actual nightly toolchain specified in repo is needed for running rustfmt in build.rs
@@ -51,7 +51,7 @@ RUN cargo chef cook \
 RUN git reset --hard
 
 FROM base AS ref
-ARG REF=v0.11.0
+ARG REF=v0.12.1
 RUN git fetch --depth=1 origin $REF && git checkout $REF
 # actual nightly toolchain specified in repo is needed for running rustfmt in build.rs
 # can be removed once https://github.com/anoma/namada/issues/40 is done

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Run `docker compose up` to build and run the ledger Docker container. See `docke
 # REF is the git commit or tag you want to build namada from
 # it must be at least this version or a later commit
 # REF must also be compatible with the `network-config.toml` in this repo (until https://github.com/anoma/anoma/issues/1105 is done, at which point we could use some pre-provided network config template)
-export REF='v0.11.0'
+export REF='v0.12.1'
 
 # BASE_POINT is built before REF, it should preferably share code and crate dependencies with REF, to help with caching
-export BASE_POINT='v0.11.0'
+export BASE_POINT='v0.12.1'
 
 docker build \
     --build-arg BASE_POINT=${BASE_POINT} \

--- a/build_network.sh
+++ b/build_network.sh
@@ -1,14 +1,36 @@
 #!/usr/bin/env bash
-# run in a namada repo, with binaries built, to build a prebuilt archive
-# ensure wasms are already built!
-# for namada v0.11+
+#
+# Script for initializing a Namada chain for local development and joining it. Note that this script trashes any
+# existing `.namada` directory in the directory it is run!
+#
+# ## Prerequisites
+# - bash
+# - Python 3
+# - toml Python pip library <https://pypi.org/project/toml/> (this is the `python3-toml` package on Ubuntu distributions)
+# - trash CLI tool (`brew install trash` on macOS or `sudo apt-get install trash-cli` on Ubuntu)
+#
+# ## How to run
+# This script should be run from the root of a Namada source code repo (<https://github.com/anoma/namada>). *.wasm files
+# must already have been built and be present under the `wasm/` directory of the Namada repo. The only parameter for the
+# shell script is the path to a network config toml compatible with the version of Namada being used. There are some
+# example network configs under `network-configs/` in this repo. Example command:
+#
+# ```shell
+# /path/to/repo/devchain-container/build_network.sh network-configs/mainline-v0.12.1.toml
+# ````
+#
+# Once the script is finished, it should be possible to straight away start running a ledger node e.g. the command
+# assuming binaries have been built is:
+#
+# ```shell
+# target/debug/namadan ledger run
+# ````
 
-# NB: MAKE SURE PYTHON CAN ACCEPT NETWORK CONNECTIONS BEFORE RUNNING THIS SCRIPT!
 set -eoux pipefail
 IFS=$'\n\t'
 
 package() {
-    # TODO: clean up on abort
+    # TODO: also clean up these files if the script is aborted or otherwise exits unsuccessfully
     trash .namada || true
     git checkout --ours -- wasm/checksums.json
     trash nohup.out || true
@@ -61,7 +83,7 @@ package() {
     tar -cvzf "${NAMADA_CHAIN_ID}.prebuilt.tar.gz" .namada
     mv "${NAMADA_CHAIN_ID}.prebuilt.tar.gz" $CHAIN_DIR
 
-    # TODO: clean up on abort
+    # TODO: also clean up these files if the script is aborted or otherwise exits unsuccessfully
     git checkout --ours -- wasm/checksums.json
     trash nohup.out
 

--- a/build_network.sh
+++ b/build_network.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# run in a namada repo, with binaries built, to build a prebuilt archive
+# ensure wasms are already built!
+# for namada v0.11+
+
+# NB: MAKE SURE PYTHON CAN ACCEPT NETWORK CONNECTIONS BEFORE RUNNING THIS SCRIPT!
+set -eoux pipefail
+IFS=$'\n\t'
+
+package() {
+    # TODO: clean up on abort
+    trash .namada || true
+    git checkout --ours -- wasm/checksums.json
+    trash nohup.out || true
+
+    export CHAIN_DIR='.hack/chains'
+    mkdir -p $CHAIN_DIR
+
+    export NETWORK_CONFIG_PATH=$1
+    export ALIAS='validator-local-dev'
+
+    target/debug/namadac utils init-genesis-validator \
+        --alias $ALIAS \
+        --net-address 127.0.0.1:26656 \
+        --commission-rate 0.1 \
+        --max-commission-rate-change 0.1 \
+        --unsafe-dont-encrypt
+
+    export DEVCHAIN_CONTAINER_DIR='/opt/workspace/heliax/repos/devchain-container'
+    export NAMADA_NETWORK_CONFIG_PATH="${CHAIN_DIR}/network-config-processed.toml"
+    $DEVCHAIN_CONTAINER_DIR/add_validator_shard.py .namada/pre-genesis/$ALIAS/validator.toml $NETWORK_CONFIG_PATH >$NAMADA_NETWORK_CONFIG_PATH
+
+    python3 wasm/checksums.py
+
+    export NAMADA_CHAIN_PREFIX='local'
+
+    target/debug/namadac utils init-network \
+        --chain-prefix "$NAMADA_CHAIN_PREFIX" \
+        --genesis-path "$NAMADA_NETWORK_CONFIG_PATH" \
+        --wasm-checksums-path wasm/checksums.json \
+        --unsafe-dont-encrypt
+
+    basename *.tar.gz .tar.gz >${CHAIN_DIR}/chain-id
+    export NAMADA_CHAIN_ID="$(cat ${CHAIN_DIR}/chain-id)"
+    trash ".namada/${NAMADA_CHAIN_ID}"
+    mv "${NAMADA_CHAIN_ID}.tar.gz" $CHAIN_DIR
+
+    export NAMADA_NETWORK_CONFIGS_SERVER='http://localhost:8123'
+    nohup bash -c "python3 -m http.server --directory ${CHAIN_DIR} 8123 &" &&
+        sleep 2 &&
+        target/debug/namadac \
+            utils join-network \
+            --genesis-validator "$ALIAS" \
+            --chain-id "${NAMADA_CHAIN_ID}" \
+            --dont-prefetch-wasm
+
+    cp wasm/*.wasm ".namada/${NAMADA_CHAIN_ID}/wasm/"
+    cp wasm/checksums.json ".namada/${NAMADA_CHAIN_ID}/wasm/"
+
+    tar -cvzf "${NAMADA_CHAIN_ID}.prebuilt.tar.gz" .namada
+    mv "${NAMADA_CHAIN_ID}.prebuilt.tar.gz" $CHAIN_DIR
+
+    # TODO: clean up on abort
+    git checkout --ours -- wasm/checksums.json
+    trash nohup.out
+
+    # don't trash anoma - so we're ready to go with the chain
+    echo "Run the ledger!"
+}
+
+main() {
+    set -x
+
+    package $@
+
+    set +x
+}
+
+main $@

--- a/build_network.sh
+++ b/build_network.sh
@@ -26,7 +26,8 @@ package() {
         --max-commission-rate-change 0.1 \
         --unsafe-dont-encrypt
 
-    export DEVCHAIN_CONTAINER_DIR='/opt/workspace/heliax/repos/devchain-container'
+    # get the directory of this script
+    export DEVCHAIN_CONTAINER_DIR="$(dirname $0)"
     export NAMADA_NETWORK_CONFIG_PATH="${CHAIN_DIR}/network-config-processed.toml"
     $DEVCHAIN_CONTAINER_DIR/add_validator_shard.py .namada/pre-genesis/$ALIAS/validator.toml $NETWORK_CONFIG_PATH >$NAMADA_NETWORK_CONFIG_PATH
 

--- a/network-config.toml
+++ b/network-config.toml
@@ -49,6 +49,8 @@ epochs_per_year = 31_536_000
 pos_gain_p = 0.1
 # The D gain factor in the Proof of Stake rewards controller
 pos_gain_d = 0.1
+# Max payload size, in bytes, for a tx batch proposal.
+max_proposal_bytes = 22020096
 
 # Proof of stake parameters.
 [pos_params]

--- a/network-configs/README.md
+++ b/network-configs/README.md
@@ -1,0 +1,3 @@
+# network-configs
+
+This directory contains example network configs meant to be used during local development.

--- a/network-configs/ethbridge-v0.12.1.toml
+++ b/network-configs/ethbridge-v0.12.1.toml
@@ -1,0 +1,110 @@
+# the genesis_time can be any time in the past - since we will want to start this chain immediately
+genesis_time = "2022-01-01T00:00:00.00Z"
+native_token = "NAM"
+
+[token.NAM]
+address = "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5"
+vp = "vp_token"
+
+[token.NAM.balances]
+atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3 = 9223372036854
+
+[established.faucet]
+address = "atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3"
+vp = "vp_testnet_faucet"
+
+[wasm.vp_implicit]
+filename = "vp_implicit.wasm"
+
+[wasm.vp_validator]
+filename = "vp_validator.wasm"
+
+[wasm.vp_user]
+filename = "vp_user.wasm"
+
+[wasm.vp_token]
+filename = "vp_token.wasm"
+
+[wasm.vp_testnet_faucet]
+filename = "vp_testnet_faucet.wasm"
+
+[wasm.vp_masp]
+filename = "vp_masp.wasm"
+
+# General protocol parameters.
+[parameters]
+# Minimum number of blocks in an epoch.
+min_num_of_blocks = 4
+# Maximum expected time per block (in seconds).
+max_expected_time_per_block = 30
+# vp whitelist
+vp_whitelist = []
+# tx whitelist
+tx_whitelist = []
+# Implicit VP WASM name
+implicit_vp = "vp_implicit"
+# Expected number of epochs per year (also sets the min duration of an epoch in seconds)
+epochs_per_year = 31_536_000
+# The P gain factor in the Proof of Stake rewards controller
+pos_gain_p = 0.1
+# The D gain factor in the Proof of Stake rewards controller
+pos_gain_d = 0.1
+# Max payload size, in bytes, for a tx batch proposal.
+max_proposal_bytes = 22020096
+
+# Proof of stake parameters.
+[pos_params]
+# Maximum number of active validators.
+max_validator_slots = 128
+# Pipeline length (in epochs). Any change in the validator set made in
+# epoch 'n' will become active in epoch 'n + pipeline_len'.
+pipeline_len = 2
+# Unbonding length (in epochs). Validators may have their stake slashed
+# for a fault in epoch 'n' up through epoch 'n + unbonding_len'.
+unbonding_len = 3
+# Votes per fundamental staking token (namnam)
+tm_votes_per_token = 1
+# Reward for proposing a block.
+block_proposer_reward = 0.125
+# Reward for voting on a block.
+block_vote_reward = 0.1
+# Maximum inflation rate per annum (10%)
+max_inflation_rate = 0.1
+# Targeted ratio of staked tokens to total tokens in the supply
+target_staked_ratio = 0.6667
+# Portion of a validator's stake that should be slashed on a duplicate
+# vote.
+duplicate_vote_min_slash_rate = 0.001
+# Portion of a validator's stake that should be slashed on a light
+# client attack.
+light_client_attack_min_slash_rate = 0.001
+
+# Governance parameters.
+[gov_params]
+# minimum amount of nam token to lock
+min_proposal_fund = 500
+# proposal code size in bytes
+max_proposal_code_size = 300000
+# min proposal period length in epochs
+min_proposal_period = 3
+# max proposal period length in epochs
+max_proposal_period = 27
+# maximum number of characters in the proposal content
+max_proposal_content_size = 10000
+# minimum epochs between end and grace epoch
+min_proposal_grace_epochs = 6
+
+# the Ethereum addresses below may need to be changed according to your local Ethereum bridge smart contract deployment
+[ethereum_bridge_params]
+min_confirmations = 100
+
+[ethereum_bridge_params.contracts]
+native_erc20 = "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"
+
+[ethereum_bridge_params.contracts.bridge]
+address = "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707"
+version = 1
+
+[ethereum_bridge_params.contracts.governance]
+address = "0x0165878A594ca255338adfa4d48449f69242Eb8F"
+version = 1

--- a/network-configs/ethbridge-v0.7.1.toml
+++ b/network-configs/ethbridge-v0.7.1.toml
@@ -1,0 +1,84 @@
+# the genesis_time can be any time in the past - since we will want to start this chain immediately
+genesis_time = "2022-01-01T00:00:00.00Z"
+
+[token.XAN]
+address = "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5"
+vp = "vp_token"
+[token.XAN.balances]
+atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3 = 9223372036854
+[established.faucet]
+address = "atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3"
+vp = "vp_testnet_faucet"
+# Wasm VP definitions
+# Default user VP
+[wasm.vp_user]
+filename = "vp_user.wasm"
+sha256 = "8bb90e43d53156c26e60082693fcb35fa0eb4a1ca3adaa5fb9e8b2ec3477ff95"
+# Token VP
+[wasm.vp_token]
+filename = "vp_token.wasm"
+sha256 = "7c9bb99a9eb45bdb62cda38b2d09b45eda22138910db5b194aa8c1ba1fdfda78"
+# Faucet VP
+[wasm.vp_testnet_faucet]
+filename = "vp_testnet_faucet.wasm"
+sha256 = "cdc7d2c6118c3f4909c700a63b97f9c734c463ac32cb30164737a2d85d6ee873"
+# General protocol parameters.
+[parameters]
+# Minimum number of blocks in an epoch.
+min_num_of_blocks = 2
+# Minimum duration of an epoch (in seconds).
+min_duration = 10
+# Maximum expected time per block (in seconds).
+max_expected_time_per_block = 30
+# Proof of stake parameters.
+[pos_params]
+# Maximum number of active validators.
+max_validator_slots = 4
+# Pipeline length (in epochs). Any change in the validator set made in
+# epoch 'n' will become active in epoch 'n + pipeline_len'.
+pipeline_len = 2
+# Unbonding length (in epochs). Validators may have their stake slashed
+# for a fault in epoch 'n' up through epoch 'n + unbonding_len'.
+unbonding_len = 4
+# Votes per token (in basis points, i.e., per 10,000 tokens)
+votes_per_token = 10
+# Reward for proposing a block.
+block_proposer_reward = 100
+# Reward for voting on a block.
+block_vote_reward = 1
+# Portion of a validator's stake that should be slashed on a duplicate
+# vote (in basis points, i.e., 500 = 5%).
+duplicate_vote_slash_rate = 500
+# Portion of a validator's stake that should be slashed on a light
+# client attack (in basis points, i.e., 500 = 5%).
+light_client_attack_slash_rate = 500
+# Governance parameters.
+[gov_params]
+# minimum amount of xan token to lock
+min_proposal_fund = 500
+# proposal code size in bytes
+max_proposal_code_size = 300000
+# proposal period length in epoch
+min_proposal_period = 3
+max_proposal_period = 5
+# maximum number of characters in the proposal content
+max_proposal_content_size = 5000
+# minimum epochs between end and grace epoch
+min_proposal_grace_epochs = 6
+[treasury_params]
+max_proposal_fund_transfer = 10000
+
+# the Ethereum addresses below may need to be changed according to your local Ethereum bridge smart contract deployment
+[ethereum_bridge_params]
+min_confirmations = 100
+
+[ethereum_bridge_params.contracts]
+native_erc20 = "0x1721b337BBdd2b11f9Eef736d9192a8E9Cba5872"
+
+[ethereum_bridge_params.contracts.bridge]
+address = "0x237d915037A1ba79365E84e2b8574301B6D25Ea0"
+version = 1
+
+[ethereum_bridge_params.contracts.governance]
+address = "0x308728EEa73538d0edEfd95EF148Eb678F71c71D"
+version = 1

--- a/network-configs/ethbridge-v0.9.0.toml
+++ b/network-configs/ethbridge-v0.9.0.toml
@@ -1,0 +1,84 @@
+# the genesis_time can be any time in the past - since we will want to start this chain immediately
+genesis_time = "2022-01-01T00:00:00.00Z"
+
+[token.nam]
+address = "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5"
+vp = "vp_token"
+[token.nam.balances]
+atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3 = 9223372036854
+[established.faucet]
+address = "atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3"
+vp = "vp_testnet_faucet"
+# Wasm VP definitions
+# Default user VP
+[wasm.vp_user]
+filename = "vp_user.wasm"
+sha256 = "8bb90e43d53156c26e60082693fcb35fa0eb4a1ca3adaa5fb9e8b2ec3477ff95"
+# Token VP
+[wasm.vp_token]
+filename = "vp_token.wasm"
+sha256 = "7c9bb99a9eb45bdb62cda38b2d09b45eda22138910db5b194aa8c1ba1fdfda78"
+# Faucet VP
+[wasm.vp_testnet_faucet]
+filename = "vp_testnet_faucet.wasm"
+sha256 = "cdc7d2c6118c3f4909c700a63b97f9c734c463ac32cb30164737a2d85d6ee873"
+# General protocol parameters.
+[parameters]
+# Minimum number of blocks in an epoch.
+min_num_of_blocks = 2
+# Minimum duration of an epoch (in seconds).
+min_duration = 10
+# Maximum expected time per block (in seconds).
+max_expected_time_per_block = 30
+# Proof of stake parameters.
+[pos_params]
+# Maximum number of active validators.
+max_validator_slots = 4
+# Pipeline length (in epochs). Any change in the validator set made in
+# epoch 'n' will become active in epoch 'n + pipeline_len'.
+pipeline_len = 2
+# Unbonding length (in epochs). Validators may have their stake slashed
+# for a fault in epoch 'n' up through epoch 'n + unbonding_len'.
+unbonding_len = 4
+# Votes per token (in basis points, i.e., per 10,000 tokens)
+votes_per_token = 10
+# Reward for proposing a block.
+block_proposer_reward = 100
+# Reward for voting on a block.
+block_vote_reward = 1
+# Portion of a validator's stake that should be slashed on a duplicate
+# vote (in basis points, i.e., 500 = 5%).
+duplicate_vote_slash_rate = 500
+# Portion of a validator's stake that should be slashed on a light
+# client attack (in basis points, i.e., 500 = 5%).
+light_client_attack_slash_rate = 500
+# Governance parameters.
+[gov_params]
+# minimum amount of xan token to lock
+min_proposal_fund = 500
+# proposal code size in bytes
+max_proposal_code_size = 300000
+# proposal period length in epoch
+min_proposal_period = 3
+max_proposal_period = 5
+# maximum number of characters in the proposal content
+max_proposal_content_size = 5000
+# minimum epochs between end and grace epoch
+min_proposal_grace_epochs = 6
+[treasury_params]
+max_proposal_fund_transfer = 10000
+
+# the Ethereum addresses below may need to be changed according to your local Ethereum bridge smart contract deployment
+[ethereum_bridge_params]
+min_confirmations = 100
+
+[ethereum_bridge_params.contracts]
+native_erc20 = "0x1721b337BBdd2b11f9Eef736d9192a8E9Cba5872"
+
+[ethereum_bridge_params.contracts.bridge]
+address = "0x237d915037A1ba79365E84e2b8574301B6D25Ea0"
+version = 1
+
+[ethereum_bridge_params.contracts.governance]
+address = "0x308728EEa73538d0edEfd95EF148Eb678F71c71D"
+version = 1

--- a/network-configs/mainline-v0.11.0.toml
+++ b/network-configs/mainline-v0.11.0.toml
@@ -1,0 +1,93 @@
+# the genesis_time can be any time in the past - since we will want to start this chain immediately
+genesis_time = "2022-01-01T00:00:00.00Z"
+native_token = "NAM"
+
+[token.NAM]
+address = "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5"
+vp = "vp_token"
+
+[token.NAM.balances]
+atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3 = 9223372036854
+
+[established.faucet]
+address = "atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3"
+vp = "vp_testnet_faucet"
+
+[wasm.vp_implicit]
+filename = "vp_implicit.wasm"
+
+[wasm.vp_validator]
+filename = "vp_validator.wasm"
+
+[wasm.vp_user]
+filename = "vp_user.wasm"
+
+[wasm.vp_token]
+filename = "vp_token.wasm"
+
+[wasm.vp_testnet_faucet]
+filename = "vp_testnet_faucet.wasm"
+
+[wasm.vp_masp]
+filename = "vp_masp.wasm"
+
+# General protocol parameters.
+[parameters]
+# Minimum number of blocks in an epoch.
+min_num_of_blocks = 4
+# Maximum expected time per block (in seconds).
+max_expected_time_per_block = 30
+# vp whitelist
+vp_whitelist = []
+# tx whitelist
+tx_whitelist = []
+# Implicit VP WASM name
+implicit_vp = "vp_implicit"
+# Expected number of epochs per year (also sets the min duration of an epoch in seconds)
+epochs_per_year = 31_536_000
+# The P gain factor in the Proof of Stake rewards controller
+pos_gain_p = 0.1
+# The D gain factor in the Proof of Stake rewards controller
+pos_gain_d = 0.1
+
+# Proof of stake parameters.
+[pos_params]
+# Maximum number of active validators.
+max_validator_slots = 128
+# Pipeline length (in epochs). Any change in the validator set made in
+# epoch 'n' will become active in epoch 'n + pipeline_len'.
+pipeline_len = 2
+# Unbonding length (in epochs). Validators may have their stake slashed
+# for a fault in epoch 'n' up through epoch 'n + unbonding_len'.
+unbonding_len = 3
+# Votes per fundamental staking token (namnam)
+tm_votes_per_token = 1
+# Reward for proposing a block.
+block_proposer_reward = 0.125
+# Reward for voting on a block.
+block_vote_reward = 0.1
+# Maximum inflation rate per annum (10%)
+max_inflation_rate = 0.1
+# Targeted ratio of staked tokens to total tokens in the supply
+target_staked_ratio = 0.6667
+# Portion of a validator's stake that should be slashed on a duplicate
+# vote.
+duplicate_vote_min_slash_rate = 0.001
+# Portion of a validator's stake that should be slashed on a light
+# client attack.
+light_client_attack_min_slash_rate = 0.001
+
+# Governance parameters.
+[gov_params]
+# minimum amount of nam token to lock
+min_proposal_fund = 500
+# proposal code size in bytes
+max_proposal_code_size = 300000
+# min proposal period length in epochs
+min_proposal_period = 3
+# max proposal period length in epochs
+max_proposal_period = 27
+# maximum number of characters in the proposal content
+max_proposal_content_size = 10000
+# minimum epochs between end and grace epoch
+min_proposal_grace_epochs = 6

--- a/network-configs/mainline-v0.12.1.toml
+++ b/network-configs/mainline-v0.12.1.toml
@@ -1,0 +1,95 @@
+# the genesis_time can be any time in the past - since we will want to start this chain immediately
+genesis_time = "2022-01-01T00:00:00.00Z"
+native_token = "NAM"
+
+[token.NAM]
+address = "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5"
+vp = "vp_token"
+
+[token.NAM.balances]
+atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3 = 9223372036854
+
+[established.faucet]
+address = "atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3"
+vp = "vp_testnet_faucet"
+
+[wasm.vp_implicit]
+filename = "vp_implicit.wasm"
+
+[wasm.vp_validator]
+filename = "vp_validator.wasm"
+
+[wasm.vp_user]
+filename = "vp_user.wasm"
+
+[wasm.vp_token]
+filename = "vp_token.wasm"
+
+[wasm.vp_testnet_faucet]
+filename = "vp_testnet_faucet.wasm"
+
+[wasm.vp_masp]
+filename = "vp_masp.wasm"
+
+# General protocol parameters.
+[parameters]
+# Minimum number of blocks in an epoch.
+min_num_of_blocks = 4
+# Maximum expected time per block (in seconds).
+max_expected_time_per_block = 30
+# vp whitelist
+vp_whitelist = []
+# tx whitelist
+tx_whitelist = []
+# Implicit VP WASM name
+implicit_vp = "vp_implicit"
+# Expected number of epochs per year (also sets the min duration of an epoch in seconds)
+epochs_per_year = 31_536_000
+# The P gain factor in the Proof of Stake rewards controller
+pos_gain_p = 0.1
+# The D gain factor in the Proof of Stake rewards controller
+pos_gain_d = 0.1
+# Max payload size, in bytes, for a tx batch proposal.
+max_proposal_bytes = 22020096
+
+# Proof of stake parameters.
+[pos_params]
+# Maximum number of active validators.
+max_validator_slots = 128
+# Pipeline length (in epochs). Any change in the validator set made in
+# epoch 'n' will become active in epoch 'n + pipeline_len'.
+pipeline_len = 2
+# Unbonding length (in epochs). Validators may have their stake slashed
+# for a fault in epoch 'n' up through epoch 'n + unbonding_len'.
+unbonding_len = 3
+# Votes per fundamental staking token (namnam)
+tm_votes_per_token = 1
+# Reward for proposing a block.
+block_proposer_reward = 0.125
+# Reward for voting on a block.
+block_vote_reward = 0.1
+# Maximum inflation rate per annum (10%)
+max_inflation_rate = 0.1
+# Targeted ratio of staked tokens to total tokens in the supply
+target_staked_ratio = 0.6667
+# Portion of a validator's stake that should be slashed on a duplicate
+# vote.
+duplicate_vote_min_slash_rate = 0.001
+# Portion of a validator's stake that should be slashed on a light
+# client attack.
+light_client_attack_min_slash_rate = 0.001
+
+# Governance parameters.
+[gov_params]
+# minimum amount of nam token to lock
+min_proposal_fund = 500
+# proposal code size in bytes
+max_proposal_code_size = 300000
+# min proposal period length in epochs
+min_proposal_period = 3
+# max proposal period length in epochs
+max_proposal_period = 27
+# maximum number of characters in the proposal content
+max_proposal_content_size = 10000
+# minimum epochs between end and grace epoch
+min_proposal_grace_epochs = 6

--- a/network-configs/mainline-v0.9.0.toml
+++ b/network-configs/mainline-v0.9.0.toml
@@ -1,0 +1,69 @@
+# the genesis_time can be any time in the past - since we will want to start this chain immediately
+genesis_time = "2022-01-01T00:00:00.00Z"
+
+[token.nam]
+address = "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5"
+vp = "vp_token"
+[token.nam.balances]
+atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3 = 9223372036854
+[established.faucet]
+address = "atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3"
+vp = "vp_testnet_faucet"
+# Wasm VP definitions
+# Default user VP
+[wasm.vp_user]
+filename = "vp_user.wasm"
+sha256 = "8bb90e43d53156c26e60082693fcb35fa0eb4a1ca3adaa5fb9e8b2ec3477ff95"
+# Token VP
+[wasm.vp_token]
+filename = "vp_token.wasm"
+sha256 = "7c9bb99a9eb45bdb62cda38b2d09b45eda22138910db5b194aa8c1ba1fdfda78"
+# Faucet VP
+[wasm.vp_testnet_faucet]
+filename = "vp_testnet_faucet.wasm"
+sha256 = "cdc7d2c6118c3f4909c700a63b97f9c734c463ac32cb30164737a2d85d6ee873"
+# General protocol parameters.
+[parameters]
+# Minimum number of blocks in an epoch.
+min_num_of_blocks = 2
+# Minimum duration of an epoch (in seconds).
+min_duration = 10
+# Maximum expected time per block (in seconds).
+max_expected_time_per_block = 30
+# Proof of stake parameters.
+[pos_params]
+# Maximum number of active validators.
+max_validator_slots = 4
+# Pipeline length (in epochs). Any change in the validator set made in
+# epoch 'n' will become active in epoch 'n + pipeline_len'.
+pipeline_len = 2
+# Unbonding length (in epochs). Validators may have their stake slashed
+# for a fault in epoch 'n' up through epoch 'n + unbonding_len'.
+unbonding_len = 4
+# Votes per token (in basis points, i.e., per 10,000 tokens)
+votes_per_token = 10
+# Reward for proposing a block.
+block_proposer_reward = 100
+# Reward for voting on a block.
+block_vote_reward = 1
+# Portion of a validator's stake that should be slashed on a duplicate
+# vote (in basis points, i.e., 500 = 5%).
+duplicate_vote_slash_rate = 500
+# Portion of a validator's stake that should be slashed on a light
+# client attack (in basis points, i.e., 500 = 5%).
+light_client_attack_slash_rate = 500
+# Governance parameters.
+[gov_params]
+# minimum amount of xan token to lock
+min_proposal_fund = 500
+# proposal code size in bytes
+max_proposal_code_size = 300000
+# proposal period length in epoch
+min_proposal_period = 3
+max_proposal_period = 5
+# maximum number of characters in the proposal content
+max_proposal_content_size = 5000
+# minimum epochs between end and grace epoch
+min_proposal_grace_epochs = 6
+[treasury_params]
+max_proposal_fund_transfer = 10000


### PR DESCRIPTION
This PR adds a new script which can be run from within a [Namada](https://github.com/anoma/namada) repo to initialize and join a new chain for local development (similar to the one that is used in the devchain container).

Works against namada v0.12.1 (and possibly later versions)